### PR TITLE
Legion: Set Kokkos_CXX_COMPILER variable for build

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -5,7 +5,7 @@
 
 
 from spack import *
-
+import os
 
 class Legion(CMakePackage):
     """Legion is a data-centric parallel programming system for writing
@@ -186,6 +186,7 @@ class Legion(CMakePackage):
         if '+kokkos' in self.spec:
             # default is off. 
             options.append('-DLegion_USE_Kokkos=ON')
+            os.environ['KOKKOS_CXX_COMPILER'] = self.spec['kokkos'].kokkos_cxx
 
         if '+libdl' in self.spec:
             # default is on.


### PR DESCRIPTION
Legion requires this variable when built with Kokkos, at least for older versions of Kokkos. Not sure at what version Kokkos provides it - my information comes from the Legion CMakeLists.txt file, and I've always set it explicitly.

I haven't tested my code against Legion built with this mod yet, so consider this an rfc until I get around to that.