### PR TITLE
Legion: Rename variants

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -39,7 +39,7 @@ class Legion(CMakePackage):
     version('18.02.0', tag='legion-18.02.0')
     version('ctrl-rep', branch='control_replication')
 
-    variant('shared-libs', default=False,
+    variant('shared_libs', default=False,
             description="Build shared libraries.")
 
     variant('network', default='none', 
@@ -47,13 +47,13 @@ class Legion(CMakePackage):
             description="The network communications layer to use.", 
             multi=False)
 
-    variant('bounds-checks', default=False,
+    variant('bounds_checks', default=False,
             description="Enable bounds checking in Legion accessors.")
-    variant('privilege-checks', default=False, 
+    variant('privilege_checks', default=False,
             description="Enable runtime privildge checks in Legion accessors.")
-    variant('enable-tls', default=False, 
+    variant('enable_tls', default=False,
             description="Enable thread-local-storage of the Legion context.")
-    variant('output-level', default='warning',
+    variant('output_level', default='warning',
             # Note: values are dependent upon Legion's cmake parameters...
             values=("spew", "debug", "info", "print", "warning", "error", "fatal", "none"),
             description="Set the compile-time logging level.", 
@@ -63,12 +63,12 @@ class Legion(CMakePackage):
 
     variant('cuda', default=False, 
             description="Enable CUDA support.")
-    variant('cuda-hijack', default=False,
+    variant('cuda_hijack', default=False,
             description="Hijack application calls into the CUDA runtime (implies +cuda).")
     # note on arch values: 60=pascal, 70=volta, 75=turing 
-    variant('cuda-arch', default='70', # default to supporting volta
             values=("60", "70", "75"), 
             description="GPU/CUDA architecture to build for.", 
+    variant('cuda_arch', default='70', # default to supporting volta
             multi=True)
     variant('fortran', default=False, 
             description="Enable Fortran bindings.")
@@ -82,7 +82,7 @@ class Legion(CMakePackage):
             description="Enable support for dynamic loading (via libdl).")
     variant('llvm', default=False,
             description="Enable support for LLVM IR JIT  within the Realm runtime.")
-    variant('link-llvm-libs', default=False,
+    variant('link_llvm_libs', default=False,
             description="Link LLVM libraries into the Realm runtime library.")
     variant('openmp', default=False,
             description="Enable support for OpenMP within Legion tasks.")
@@ -92,37 +92,39 @@ class Legion(CMakePackage):
             description="Enable Python support.")
     variant('zlib', default=True, 
             description="Enable zlib support.")
-    
-    variant('redop-complex', default=False,
+
+    variant('redop_complex', default=False,
             description="Use reduction operators for complex types.")
     
-    variant('build-all', default=False, 
+
+    variant('build_all', default=False,
             description="Build everything: all bindings, examples, tutorials, tests, apps, etc.")
-    variant('build-apps', default=False, 
+    variant('build_apps', default=False,
             description="Build the sample applicaitons.")
-    variant('build-bindings', default=False, 
+    variant('build_bindings', default=False,
             description="Build all the language bindings (C, Fortran, Python, etc.).")
-    variant('build-examples', default=False, 
+    variant('build_examples', default=False,
             description="Build the (small'ish) examples.")
-    variant('build-tests', default=False, 
+    variant('build_tests', default=False,
             description="Build the test suite.")
-    variant('build-tutorial', default=False, 
+    variant('build_tutorial', default=False,
             description="Build the Legion tutorial examples.")
     
 
-    variant('max-dims', values=int, default=3, 
+
+    variant('max_dims', values=int, default=3,
             description="Set the maximum number of dimensions available in a logical region.")
-    variant('max-fields', values=int, default=512,
+    variant('max_fields', values=int, default=512,
             description="Maximum number of fields allowed in a logical region.")
 
-    conflicts('+cuda-hijack', when='-cuda')
+    conflicts('+cuda_hijack', when='~cuda')
 
     depends_on("cmake@3.1:", type='build')
     depends_on('mpi', when='network=mpi')
     depends_on('gasnetex', when='network=gasnetex')
     depends_on('hdf5', when='+hdf5')
     depends_on('llvm@7.1.0', when='+llvm')
-    depends_on('llvm@7.1.0', when='+link-llvm-libs')
+    depends_on('llvm@7.1.0', when='+link_llvm_libs')
     depends_on('cuda@10:', when='+cuda')
     depends_on('hdf5', when='+hdf5')
     depends_on('zlib@1.2.11', when="zlib")
@@ -144,11 +146,11 @@ class Legion(CMakePackage):
         if '+privilege_checks' in self.spec:
             # default is off. 
             options.append('-DLegion_PRIVILEGE_CHECKS=ON')
-        if '+enable-tls' in self.spec:
-            # default is off. 
+        if '+enable_tls' in self.spec:
+            # default is off.
             options.append('-DLegion_ENABLE_TLS=ON')
-        if 'output-level' in self.spec:
-            level = str.upper(self.spec.variants['output-level'].value)
+        if 'output_level' in self.spec:
+            level = str.upper(self.spec.variants['output_level'].value)
             options.append('-DLegion_OUTPUT_LEVEL=%s' % level)
         if '+spy' in self.spec:
             # default is off. 
@@ -161,12 +163,12 @@ class Legion(CMakePackage):
         # else is no-op... 
         
         if '+cuda' in self.spec:
-            cuda_arch = list(self.spec.variants['cuda-arch'].value)
+            cuda_arch = list(self.spec.variants['cuda_arch'].value)
             arch_str = ','.join(cuda_arch)
             options.append('-DLegion_USE_CUDA=ON')
             options.append('-DLegion_GPU_REDUCTIONS=ON')
             options.append('-DLegion_CUDA_ARCH=%s' % arch_str)
-            if '+cuda-hijack' in self.spec:
+            if '+cuda_hijack' in self.spec:
                 options.append('-DLegion_HIJACK_CUDART=ON')
             else:
                 options.append('-DLegion_HIJACK_CUDART=OFF')
@@ -196,7 +198,7 @@ class Legion(CMakePackage):
         if '+llvm' in self.spec:
             # default is off.
             options.append('-DLegion_USE_LLVM=ON')
-        if '+link-llvm-libs' in self.spec:
+        if '+link_llvm_libs' in self.spec:
             options.append('-DLegion_LINK_LLVM_LIBS=ON')
             # TODO: What do we want to do w/ this option?
             options.append('-DLegion_ALLOW_MISSING_LLVM_LIBS=OFF')
@@ -219,26 +221,26 @@ class Legion(CMakePackage):
         else:
             options.append('-DLegion_USE_ZLIB=OFF')
 
-        
-        if '+redop-complex' in self.spec:
-            # default is off. 
+
+        if '+redop_complex' in self.spec:
+            # default is off.
             options.append('-DLegion_REDOP_COMPLEX=ON')
 
 
         if '+build_all' in self.spec:
             # default is off. 
             options.append('-DLegion_BUILD_ALL=ON')
-        if '+build-apps' in self.spec:
-            # default is off. 
+        if '+build_apps' in self.spec:
+            # default is off.
             options.append('-DLegion_BUILD_APPS=ON')
-        if '+build-bindings' in self.spec:
-            # default is off. 
+        if '+build_bindings' in self.spec:
+            # default is off.
             options.append('-DLegion_BUILD_BINDINGS=ON')
-        if '+build-examples' in self.spec:
+        if '+build_examples' in self.spec:
             options.append('-DLegion_BUILD_EXAMPLES=ON')
-        if '+build-tests' in self.spec:
+        if '+build_tests' in self.spec:
             options.append('-DLegion_BUILD_TESTS=ON')
-        if '+build-tutorial' in self.spec:
+        if '+build_tutorial' in self.spec:
             options.append('-DLegion_BUILD_TUTORIAL=ON')
 
         if self.spec.variants['build_type'].value == 'Debug':
@@ -248,12 +250,12 @@ class Legion(CMakePackage):
                 '-ggdb',
             ])
 
-        if '+max-dims' in self.spec:
-            maxdim = self.spec.variants['max-dims'].value
+        if '+max_dims' in self.spec:
+            maxdim = self.spec.variants['max_dims'].value
             options.append('-DLegion_MAX_DIM=%d' % maxdim)
-        
-        if '+max-fields' in self.spec:
-            maxfields = self.spec.variants['max-fields'].value
+
+        if '+max_fields' in self.spec:
+            maxfields = self.spec.variants['max_fields'].value
             option.append('-DLegion_MAX_FIELDS=%d' % maxfields)
 
         options.append('-DCMAKE_CXX_FLAGS=%s' % (" ".join(cmake_cxx_flags)))


### PR DESCRIPTION
Replace dashes with underscores in variant names, which conform better with Spack conventions.