### PR TITLE
FlexFlow: Fix some variant() usage errors

### DIFF
--- a/var/spack/repos/builtin/packages/flexflow/package.py
+++ b/var/spack/repos/builtin/packages/flexflow/package.py
@@ -15,19 +15,19 @@ class Flexflow(CMakePackage):
     git      = "https://github.com/flexflow/FlexFlow.git"
 
 
-    variant('build-alexnet', Default=False,
+    variant('build-alexnet', default=False,
             description="Build the Alexnet example.")
-    variant('build-alexnet-newapi', Defualt=False,
+    variant('build-alexnet-newapi', default=False,
             description="Build the Alexnet example using the new API.")
-    variant('build-all-examples', Default=False,
+    variant('build-all-examples', default=False,
             description="Build all of the example networks.")
-    variant('build-candle-uno', Default=False,
+    variant('build-candle-uno', default=False,
             description="Build the CANDLE UNO example network.")
-    variant('build-dlrm', Default=False,
+    variant('build-dlrm', default=False,
             description="Build the DLRM example network.")
-    variant('build-inception', Default=False, 
+    variant('build-inception', default=False,
             description="Build the Inception example network.")
-    variant('build-poca')
+    #variant('build-poca')
 
     depends_on('legion@stable+cuda+cuda-hijack')
     depends_on('protobuf@3.12:')


### PR DESCRIPTION
I don't use FlexFlow, but the errors fixed by this commit were interfering in Spack with the Legion build dependent on CUDA (not sure why). These fixes mainly correct typos, except for one call to `variant()` with missing args, which I just commented out.