### PR TITLE
Legion: Set BUILD_MARCH based on Spack architecture

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -256,6 +256,8 @@ class Legion(CMakePackage):
             maxfields = self.spec.variants['max-fields'].value
             option.append('-DLegion_MAX_FIELDS=%d' % maxfields)
 
+        options.append('-DBUILD_MARCH:STRING=%s' % self.spec.architecture.target)
+
         options.append('-DCMAKE_CXX_FLAGS=%s' % (" ".join(cmake_cxx_flags)))
 
         return options


### PR DESCRIPTION
This supports consistency in the -march flag set by Legion CMake and the
Spack compiler wrapper. S